### PR TITLE
Fixed jslint fail on warning

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -50,7 +50,6 @@ gulp.task('js-lint', function () {
   return gulp.src(_config.paths.js.src)
     .pipe(jshint())
     .pipe(jshint.reporter('jshint-stylish'))
-    .pipe(jshint.reporter('fail'));
 });
 
 


### PR DESCRIPTION
Currently jslint fails on warnings.

Removed this line so that it only fails on errors
