### PR TITLE
Default DoubleClick z-indexes

### DIFF
--- a/base-template/overwrite.scss
+++ b/base-template/overwrite.scss
@@ -15,6 +15,7 @@
   height: calculate-rem({{height}} - 2);
   position: absolute;
   width: calculate-rem({{width}} - 2);
+  z-index: 9997;
 }
 
 .full-dimension {

--- a/base-template/scss/_trumps.helpers.scss
+++ b/base-template/scss/_trumps.helpers.scss
@@ -29,6 +29,7 @@
   position: absolute;
   top: 0;
   width: 100%;
+  z-index: 9999;
 }
 
 #covering-div {
@@ -38,4 +39,5 @@
   top: 0;
   transition: opacity 1.2s ease;
   width: 100%;
+  z-index: 9998;
 }


### PR DESCRIPTION
Added default z-indexes for DoubleClick specific components, which should always sit at the top of the banner. Components are layered in the following order:
- bg-exit (9999)
- covering-div (9998)
- banner-border (9997)
